### PR TITLE
Target Saxon-HE 10

### DIFF
--- a/src/main/java/org/expath/tools/saxon/model/SaxonElement.java
+++ b/src/main/java/org/expath/tools/saxon/model/SaxonElement.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import javax.xml.namespace.QName;
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.om.AxisInfo;
-import net.sf.saxon.om.InscopeNamespaceResolver;
 import net.sf.saxon.om.NamePool;
 import net.sf.saxon.om.NamespaceResolver;
 import net.sf.saxon.om.NodeInfo;
@@ -181,7 +180,7 @@ public class SaxonElement
             throws ToolsException
     {
         try {
-            NamespaceResolver resolver = new InscopeNamespaceResolver(myNode);
+            NamespaceResolver resolver = myNode.getAllNamespaces();
             StructuredQName name = StructuredQName.fromLexicalQName(value, true, false, resolver);
             return name.toJaxpQName();
         }

--- a/src/main/java/org/expath/tools/saxon/model/SaxonTreeBuilder.java
+++ b/src/main/java/org/expath/tools/saxon/model/SaxonTreeBuilder.java
@@ -46,9 +46,13 @@ public class SaxonTreeBuilder
 
     /**
      * Provide the result in Saxon's object tools.
+     *
+     * @return the node info
+     *
+     * @throws ToolsException if the root cannot be obtained
      */
     public NodeInfo getCurrentRoot()
-        throws ToolsException
+            throws ToolsException
     {
         try {
             writer.writeEndDocument();
@@ -62,22 +66,22 @@ public class SaxonTreeBuilder
     }
 
     @Override
-    public void startElem(String s)
+    public void startElem(String localname)
             throws ToolsException
     {
         try {
-            writer.writeStartElement(myPrefix, s, myNs);
+            writer.writeStartElement(myPrefix, localname, myNs);
         } catch (XMLStreamException ex) {
             throw new ToolsException("Error starting element on the Saxon tree builder", ex);
         }
     }
 
     @Override
-    public void attribute(String s, CharSequence charSequence)
+    public void attribute(String localname, CharSequence value)
             throws ToolsException
     {
         try {
-            writer.writeAttribute(s, (String) charSequence);
+            writer.writeAttribute(localname, (String) value);
         } catch (XMLStreamException ex) {
             throw new ToolsException("Error creating attribute on the Saxon tree builder", ex);
         }


### PR DESCRIPTION
I was not sure how best to approach this. Apparently the Receiver interface had a not trivial update to method signatures in Saxon 10, so e.g. the Receiver.startElement method now needs all attributes up front. In the end I tried to re-implement it using a [BuildingStreamWriter](https://www.saxonica.com/html/documentation/javadoc/net/sf/saxon/s9api/BuildingStreamWriter.html) which takes StAX methods.

I don't know if you have any other suggestions, but I could probably have a look if given some pointers.