### PR TITLE
Remove call to writeNamespace, fixes #3

### DIFF
--- a/src/main/java/org/expath/tools/saxon/model/SaxonTreeBuilder.java
+++ b/src/main/java/org/expath/tools/saxon/model/SaxonTreeBuilder.java
@@ -38,7 +38,6 @@ public class SaxonTreeBuilder
             DocumentBuilder builder = processor.newDocumentBuilder();
             writer = builder.newBuildingStreamWriter();
             writer.writeStartDocument();
-            writer.writeNamespace(prefix, ns);
         } catch (SaxonApiException | XMLStreamException ex) {
             throw new ToolsException("Could not create Saxon builder", ex);
         }


### PR DESCRIPTION
Unfortunately I misused the `writeNamespace` method. But I found that namespace declarations are generated automatically, so I think it is safe to remove the call entirely.